### PR TITLE
Add /request endpoint to perform test requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,8 @@ value to `GET /env1` on port 80.
 
 When started with environment variable `GNOMOCK_TEST_2`, it replies with its
 value to `GET /env2` on port 8080.
+
+When started with environment variable `GNOMOCK_REQUEST_TARGET`, it performs a
+`GET` request to that URL (i.e `http://container-name`) and returns the same
+status code it received from the target, every time it receives a new request
+to `/request` endpoint.

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 func main() {
 	env1 := os.Getenv("GNOMOCK_TEST_1")
 	env2 := os.Getenv("GNOMOCK_TEST_2")
+	requestTarget := os.Getenv("GNOMOCK_REQUEST_TARGET")
 
 	fmt.Println("received args:", os.Args[1:])
 	fmt.Printf("starting with env1 = '%s', env2 = '%s'\n", env1, env2)
@@ -17,6 +18,15 @@ func main() {
 	mux80 := http.NewServeMux()
 	mux80.HandleFunc("/", echoHandler("80"))
 	mux80.HandleFunc("/env1", echoHandler(env1))
+	mux80.HandleFunc("/request", func(w http.ResponseWriter, r *http.Request) {
+		res, err := http.Get(requestTarget)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		w.WriteHeader(res.StatusCode)
+	})
 
 	mux8080 := http.NewServeMux()
 	mux8080.HandleFunc("/", echoHandler("8080"))


### PR DESCRIPTION
This PR creates a way to tests custom networks feature introduced in https://github.com/orlangure/gnomock/pull/534/.